### PR TITLE
Melhoria visual no avatar do currículo

### DIFF
--- a/src/components/curriculum/elements/Avatar.vue
+++ b/src/components/curriculum/elements/Avatar.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="avatar-root" v-if="!loading">
 		<div class="avatar pointer" @click="$editing ? $refs.uploader.click() : false">
-			<img ref="avatarImg" :data-src="avatarUrl" :src="avatarUrl" :key="avatarUrl">
+			<img alt=" " ref="avatarImg" :data-src="avatarUrl" :src="avatarUrl" :key="avatarUrl">
 			<i v-if="$editing" class="fa fa-camera"></i>
 			
 			<div v-if="$editing">


### PR DESCRIPTION
Quando imagem do avatar não é carregada corretamente (em que o caminho não esta correto ou não existe) é exibido uma leve borda no elemento, essa borda é uma disposição de imagem de fallback padrão do HTML.

Foi corrigido adicionando o atributo `alt` com valor vazio para respectiva imagem onde é carregada o avatar.

Antes:
![Screen Shot 2021-10-19 at 21 58 29](https://user-images.githubusercontent.com/55795035/138010633-fdea6900-4e96-4cd6-b220-369f8d384fa6.png)

Depois:
![Screen Shot 2021-10-19 at 21 49 46](https://user-images.githubusercontent.com/55795035/138010655-e65f93de-e919-491f-9dc3-661b06002256.png)

